### PR TITLE
インストールしたgemを永続化できるようにし、BUNDLE_PATHを明示

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,10 @@ services:
       - "3000:3000"
     volumes:
       - .:/app
+      - bundle:/app/vendor/bundle
     environment:
-      - BINDING=0.0.0.0
+      BINDING: "0.0.0.0"
+      BUNDLE_PATH: "/app/vendor/bundle"
     depends_on:
       - db
     tty: true
@@ -20,4 +22,5 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: 'trust'
 volumes:
+  bundle:
   db:


### PR DESCRIPTION
- bundle installでインストールしたgemを永続化できるようにbundleのvolumeを追加
- BUNDLE_PATHの環境変数を追加し、Gemをインストールするディレクトリを指定するようにした